### PR TITLE
Implement menu pages and extended services

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,9 @@ import Layout from "./components/ui/Layout";
 import Home from "./pages/Home";
 import ProductsPage from "./pages/ProductsPage";
 import ProductPage from "./pages/ProductPage";
+import ServicesPage from "./pages/ServicesPage";
+import SocialServicesPage from "./pages/SocialServicesPage";
+import AboutPage from "./pages/AboutPage";
 import CartPage from "./pages/CartPage";
 import Register from "./pages/Register";
 import LoginPopup from "./components/ui/LoginPopup";
@@ -19,6 +22,9 @@ const App = () => {
         <Route path="/" element={<Home />} />
         <Route path="/products" element={<ProductsPage />} />
         <Route path="/product/:id" element={<ProductPage />} />
+        <Route path="/services" element={<ServicesPage />} />
+        <Route path="/social" element={<SocialServicesPage />} />
+        <Route path="/about" element={<AboutPage />} />
         <Route path="/cart" element={<CartPage />} />
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<LoginPopup />} />

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -92,7 +92,8 @@ const Header = () => {
     "Window Perfs",
     "Yard Signs",
 ];
-  const services = [ "Design Services",
+  const services = [
+    "Design Services",
     "Business Cards",
     "Postcards",
     "Envelopes",
@@ -102,15 +103,27 @@ const Header = () => {
     "Logo Design Services",
     "All Design Services",
     "Every Door Direct Mail ®",
+    "6 x 11 EDDM® Postcards",
+    "6.5 x 8 EDDM® Postcards",
+    "6.5 x 9 EDDM® Postcards",
     "All EDDM® Services",
     "Mailing Services",
+    "4 x 6 Postcards",
+    "5 x 7 Postcards",
+    "5.5 x 8.5 Postcards",
+    "6 x 11 Postcards",
     "All Mailing Services",
     "Direct Marketing Packages",
+    "1: 4 x 6 Postcards - 1,000 qty",
+    "2: 4 x 6 Postcards - 2,500 qty",
+    "3: 4 x 6 Postcards - 5,000 qty",
+    "4: 5.5 x 8.5 Postcards - 1,000 qty",
+    "5: 5.5 x 8.5 Postcards - 2,500 qty",
     "All Direct Marketing Packages",
     "Other Services",
     "Print Brokers",
     "Free Sample Kit",
-];
+  ];
   const socialServices = ["Instagram Ads", "TikTok Promotions", "LinkedIn Campaigns"];
 
   const groupedProducts = groupedByAlphabet(products);

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const AboutPage = () => {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold mb-6 text-center">About Us</h1>
+      <p className="text-lg text-center">
+        This project is a simple showcase of printing and design services.
+      </p>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/src/pages/ServicesPage.jsx
+++ b/src/pages/ServicesPage.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+const services = [
+  "Design Services",
+  "Business Cards",
+  "Postcards",
+  "Envelopes",
+  "Greeting Cards",
+  "Banners",
+  "Yard Signs",
+  "Logo Design Services",
+  "All Design Services",
+  "Every Door Direct Mail ®",
+  "6 x 11 EDDM® Postcards",
+  "6.5 x 8 EDDM® Postcards",
+  "6.5 x 9 EDDM® Postcards",
+  "All EDDM® Services",
+  "Mailing Services",
+  "4 x 6 Postcards",
+  "5 x 7 Postcards",
+  "5.5 x 8.5 Postcards",
+  "6 x 11 Postcards",
+  "All Mailing Services",
+  "Direct Marketing Packages",
+  "1: 4 x 6 Postcards - 1,000 qty",
+  "2: 4 x 6 Postcards - 2,500 qty",
+  "3: 4 x 6 Postcards - 5,000 qty",
+  "4: 5.5 x 8.5 Postcards - 1,000 qty",
+  "5: 5.5 x 8.5 Postcards - 2,500 qty",
+  "All Direct Marketing Packages",
+  "Other Services",
+  "Print Brokers",
+  "Free Sample Kit",
+];
+
+const ServicesPage = () => {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold mb-6 text-center">Our Services</h1>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {services.map((service, index) => (
+          <li key={index} className="border p-4 rounded shadow-sm">
+            {service}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ServicesPage;

--- a/src/pages/SocialServicesPage.jsx
+++ b/src/pages/SocialServicesPage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const socialServices = [
+  'Instagram Ads',
+  'TikTok Promotions',
+  'LinkedIn Campaigns',
+];
+
+const SocialServicesPage = () => {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold mb-6 text-center">Social Services</h1>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {socialServices.map((service, index) => (
+          <li key={index} className="border p-4 rounded shadow-sm">
+            {service}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SocialServicesPage;


### PR DESCRIPTION
## Summary
- add placeholder pages for Services, Social Services, and About
- wire new pages into the router
- extend list of services in the menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886ba11c8d083319084d6cea291d085